### PR TITLE
fix: add chat mappers path to Vite configuration and update extension API repository details

### DIFF
--- a/apps/electron/vite.config.ts
+++ b/apps/electron/vite.config.ts
@@ -5,6 +5,7 @@ import { resolve } from 'path'
 const uiVuePath = resolve(__dirname, '../../packages/ui-vue/src')
 const corePath = resolve(__dirname, '../../packages/core/src')
 const i18nPath = resolve(__dirname, '../../packages/i18n/src')
+const chatMappersPath = resolve(__dirname, '../../packages/chat/src/mappers/index.ts')
 
 export default defineConfig({
   plugins: [vue()],
@@ -16,13 +17,14 @@ export default defineConfig({
       '@stina/ui-vue': uiVuePath,
       '@stina/core': corePath,
       '@stina/i18n': i18nPath,
+      '@stina/chat/mappers': chatMappersPath,
     },
   },
   optimizeDeps: {
-    exclude: ['@stina/ui-vue', '@stina/core', '@stina/i18n'],
+    exclude: ['@stina/ui-vue', '@stina/core', '@stina/i18n', '@stina/chat/mappers'],
   },
   ssr: {
-    noExternal: ['@stina/ui-vue', '@stina/core', '@stina/i18n'],
+    noExternal: ['@stina/ui-vue', '@stina/core', '@stina/i18n', '@stina/chat/mappers'],
   },
   build: {
     outDir: 'dist/renderer',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,7 @@ import { resolve } from 'path'
 const uiVuePath = resolve(__dirname, '../../packages/ui-vue/src')
 const corePath = resolve(__dirname, '../../packages/core/src')
 const i18nPath = resolve(__dirname, '../../packages/i18n/src')
+const chatMappersPath = resolve(__dirname, '../../packages/chat/src/mappers/index.ts')
 
 export default defineConfig({
   plugins: [vue()],
@@ -14,13 +15,14 @@ export default defineConfig({
       '@stina/ui-vue': uiVuePath,
       '@stina/core': corePath,
       '@stina/i18n': i18nPath,
+      '@stina/chat/mappers': chatMappersPath,
     },
   },
   optimizeDeps: {
-    exclude: ['@stina/ui-vue', '@stina/core', '@stina/i18n'],
+    exclude: ['@stina/ui-vue', '@stina/core', '@stina/i18n', '@stina/chat/mappers'],
   },
   ssr: {
-    noExternal: ['@stina/ui-vue', '@stina/core', '@stina/i18n'],
+    noExternal: ['@stina/ui-vue', '@stina/core', '@stina/i18n', '@stina/chat/mappers'],
   },
   server: {
     port: 3002,

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,6 +2,10 @@
   "name": "@stina/extension-api",
   "version": "0.6.2",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/einord/stina"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This pull request updates configuration files for both the Electron and Web apps to add support for the new `@stina/chat/mappers` module, and also adds repository metadata to the `@stina/extension-api` package. These changes improve module resolution and dependency management for the chat mappers and enhance package metadata for publishing.

Module resolution and dependency configuration:

* Added a new alias for `@stina/chat/mappers` in both `apps/electron/vite.config.ts` and `apps/web/vite.config.ts`, pointing to `packages/chat/src/mappers/index.ts` to enable direct imports of chat mappers. [[1]](diffhunk://#diff-c85bc9d6b8e3642bd15007fa5af3f795c789b78b29538536d8a5ff797586cc97R8) [[2]](diffhunk://#diff-eea049695b0188b525a44f51269fe670485ed3e355f8cede185cafedec24d786R8)
* Updated `optimizeDeps.exclude` and `ssr.noExternal` arrays in both Vite config files to include `@stina/chat/mappers`, ensuring proper handling of the new module during development and server-side rendering. [[1]](diffhunk://#diff-c85bc9d6b8e3642bd15007fa5af3f795c789b78b29538536d8a5ff797586cc97R20-R27) [[2]](diffhunk://#diff-eea049695b0188b525a44f51269fe670485ed3e355f8cede185cafedec24d786R18-R25)

Package metadata:

* Added a `repository` field to `packages/extension-api/package.json` to specify the GitHub repository, improving discoverability and standardizing package metadata.