### PR TITLE
fix: add 'background.workers' to valid permissions set

### DIFF
--- a/packages/extension-host/src/ManifestValidator.permissions.ts
+++ b/packages/extension-host/src/ManifestValidator.permissions.ts
@@ -25,6 +25,7 @@ export const VALID_PERMISSIONS = new Set([
   'panels.register',
   'events.emit',
   'scheduler.register',
+  'background.workers',
   'files.read',
   'files.write',
   'clipboard.read',


### PR DESCRIPTION
This pull request adds a new permission to the set of valid permissions in the extension manifest validator.

- Permissions Update:
  * Added `'background.workers'` to the `VALID_PERMISSIONS` set in `ManifestValidator.permissions.ts`, allowing extensions to request this permission.