### PR TITLE
fix: update data retrieval to include extension ID in parsed results

### DIFF
--- a/packages/adapters-node/src/extensions/storageExecutor.ts
+++ b/packages/adapters-node/src/extensions/storageExecutor.ts
@@ -182,7 +182,7 @@ export function createStorageExecutor(config: StorageExecutorConfig) {
     return rows.map((row, index) => {
       try {
         const doc = JSON.parse(row.data)
-        return { _id: row.id, ...doc }
+        return { ...doc, _id: row.id }
       } catch (error) {
         throw new Error(`Failed to parse stored data at index ${index} in collection "${collection}": ${error instanceof Error ? error.message : 'Unknown error'}`)
       }


### PR DESCRIPTION
This pull request updates the way documents are returned from the storage executor's query results. Now, each returned document will explicitly include its database `_id` field, making it easier to identify and work with individual documents in downstream processes.

**Improvements to query result structure:**

* Modified the storage executor's select query logic in `storageExecutor.ts` so that each returned document includes its database `id` as `_id` in the result object.