### PR TITLE
feat: improved tool confirmation logic

### DIFF
--- a/apps/api/src/routes/chat/sessionManager.ts
+++ b/apps/api/src/routes/chat/sessionManager.ts
@@ -5,6 +5,7 @@ import {
   ModelConfigRepository,
   UserSettingsRepository,
   AppSettingsStore,
+  ToolConfirmationRepository,
 } from '@stina/chat/db'
 import type { ChatDb } from '@stina/chat/db'
 import {
@@ -162,6 +163,10 @@ function createSessionManager(userId: string, deps: {
           eventBus: conversationEventBus,
           confirmationStore: pendingConfirmationStore,
           subscriberId: randomUUID(),
+          getToolConfirmationOverride: async (extensionId, toolId) => {
+            const repo = new ToolConfirmationRepository(getDb(), userId)
+            return repo.get(extensionId, toolId)
+          },
         },
         { pageSize: 10 }
       )

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -242,6 +242,14 @@ const electronAPI = {
     ipcRenderer.invoke('extensions-get-provider-models', providerId, options),
   getExtensionTools: (extensionId: string): Promise<ExtensionToolInfo[]> =>
     ipcRenderer.invoke('extensions-get-tools', extensionId),
+  getToolConfirmations: (extensionId: string): Promise<Array<{ extensionId: string; toolId: string; requiresConfirmation: boolean; updatedAt: string }>> =>
+    ipcRenderer.invoke('extensions-get-tool-confirmations', extensionId),
+  setToolConfirmation: (extensionId: string, toolId: string, requiresConfirmation: boolean): Promise<{ success: boolean }> =>
+    ipcRenderer.invoke('extensions-set-tool-confirmation', extensionId, toolId, requiresConfirmation),
+  removeToolConfirmation: (extensionId: string, toolId: string): Promise<{ success: boolean }> =>
+    ipcRenderer.invoke('extensions-remove-tool-confirmation', extensionId, toolId),
+  resetToolConfirmations: (extensionId: string): Promise<{ success: boolean }> =>
+    ipcRenderer.invoke('extensions-reset-tool-confirmations', extensionId),
   uploadLocalExtension: (buffer: ArrayBuffer, filename: string): Promise<InstallLocalResult> =>
     ipcRenderer.invoke('extensions-upload-local', buffer, filename),
 

--- a/apps/electron/src/renderer/api/client.ts
+++ b/apps/electron/src/renderer/api/client.ts
@@ -160,6 +160,12 @@ export function createIpcApiClient(): ApiClient {
       getProviderModels: (providerId: string, options?: { settings?: Record<string, unknown> }) =>
         api.getExtensionProviderModels(providerId, options),
       getTools: (extensionId: string) => api.getExtensionTools(extensionId),
+      getToolConfirmations: (extensionId: string) => api.getToolConfirmations(extensionId),
+      setToolConfirmation: (extensionId: string, toolId: string, requiresConfirmation: boolean) =>
+        api.setToolConfirmation(extensionId, toolId, requiresConfirmation),
+      removeToolConfirmation: (extensionId: string, toolId: string) =>
+        api.removeToolConfirmation(extensionId, toolId),
+      resetToolConfirmations: (extensionId: string) => api.resetToolConfirmations(extensionId),
       uploadLocal: async (file: File): Promise<InstallLocalResult> => {
         const buffer = await file.arrayBuffer()
         return api.uploadLocalExtension(buffer, file.name)

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -33,6 +33,7 @@ import type {
   ToolSettingsViewInfo,
   ActionInfo,
   ExtensionToolInfo,
+  ToolConfirmationOverride,
   User,
   DeviceInfo,
   Invitation,
@@ -968,6 +969,80 @@ export function createHttpApiClient(options: ApiClientOptions): ApiClient {
 
         if (!response.ok) {
           throw new Error(`Failed to fetch extension tools: ${response.statusText}`)
+        }
+
+        return response.json()
+      },
+
+      async getToolConfirmations(extensionId: string): Promise<ToolConfirmationOverride[]> {
+        const response = await fetch(
+          `${API_BASE}/extensions/${encodeURIComponent(extensionId)}/tool-confirmations`,
+          {
+            headers: getAuthHeaders(options),
+          }
+        )
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch tool confirmations: ${response.statusText}`)
+        }
+
+        return response.json()
+      },
+
+      async setToolConfirmation(
+        extensionId: string,
+        toolId: string,
+        requiresConfirmation: boolean
+      ): Promise<{ success: boolean }> {
+        const response = await fetch(
+          `${API_BASE}/extensions/${encodeURIComponent(extensionId)}/tool-confirmations/${encodeURIComponent(toolId)}`,
+          {
+            method: 'PUT',
+            headers: {
+              ...getAuthHeaders(options),
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ requiresConfirmation }),
+          }
+        )
+
+        if (!response.ok) {
+          throw new Error(`Failed to set tool confirmation: ${response.statusText}`)
+        }
+
+        return response.json()
+      },
+
+      async removeToolConfirmation(
+        extensionId: string,
+        toolId: string
+      ): Promise<{ success: boolean }> {
+        const response = await fetch(
+          `${API_BASE}/extensions/${encodeURIComponent(extensionId)}/tool-confirmations/${encodeURIComponent(toolId)}`,
+          {
+            method: 'DELETE',
+            headers: getAuthHeaders(options),
+          }
+        )
+
+        if (!response.ok) {
+          throw new Error(`Failed to remove tool confirmation: ${response.statusText}`)
+        }
+
+        return response.json()
+      },
+
+      async resetToolConfirmations(extensionId: string): Promise<{ success: boolean }> {
+        const response = await fetch(
+          `${API_BASE}/extensions/${encodeURIComponent(extensionId)}/tool-confirmations`,
+          {
+            method: 'DELETE',
+            headers: getAuthHeaders(options),
+          }
+        )
+
+        if (!response.ok) {
+          throw new Error(`Failed to reset tool confirmations: ${response.statusText}`)
         }
 
         return response.json()

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -17,6 +17,7 @@ export type {
   ToolSettingsViewInfo,
   PanelViewInfo,
   ExtensionToolInfo,
+  ToolConfirmationOverride,
   ActionInfo,
   ExtensionEvent,
   ChatEvent,

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -184,6 +184,20 @@ export interface ExtensionToolInfo {
   name: LocalizedString
   description: LocalizedString
   parameters?: Record<string, unknown>
+  /** Whether this tool requires user confirmation before execution */
+  requiresConfirmation: boolean
+  /** Optional custom confirmation prompt */
+  confirmationPrompt?: LocalizedString
+}
+
+/**
+ * Tool confirmation override set by user
+ */
+export interface ToolConfirmationOverride {
+  extensionId: string
+  toolId: string
+  requiresConfirmation: boolean
+  updatedAt: string
 }
 
 /**
@@ -496,6 +510,22 @@ export interface ApiClient {
 
     /** Get tools registered by an extension */
     getTools(extensionId: string): Promise<ExtensionToolInfo[]>
+
+    /** Get tool confirmation overrides for an extension */
+    getToolConfirmations(extensionId: string): Promise<ToolConfirmationOverride[]>
+
+    /** Set tool confirmation override for a specific tool */
+    setToolConfirmation(
+      extensionId: string,
+      toolId: string,
+      requiresConfirmation: boolean
+    ): Promise<{ success: boolean }>
+
+    /** Remove tool confirmation override (revert to default) */
+    removeToolConfirmation(extensionId: string, toolId: string): Promise<{ success: boolean }>
+
+    /** Reset all tool confirmation overrides for an extension */
+    resetToolConfirmations(extensionId: string): Promise<{ success: boolean }>
 
     /** Upload and install a local extension from a file */
     uploadLocal(file: File): Promise<InstallLocalResult>

--- a/packages/builtin-tools/src/index.ts
+++ b/packages/builtin-tools/src/index.ts
@@ -18,7 +18,8 @@ function toRegisteredTool(tool: BuiltinTool): RegisteredTool {
     name: tool.name,
     description: tool.description,
     parameters: tool.parameters,
-    confirmation: tool.confirmation,
+    requiresConfirmation: tool.requiresConfirmation !== false, // default true
+    confirmationPrompt: tool.confirmationPrompt,
     extensionId: BUILTIN_EXTENSION_ID,
     execute: (params: Record<string, unknown>, context?: ToolExecutionContext) =>
       tool.execute(params, context),

--- a/packages/builtin-tools/src/types.ts
+++ b/packages/builtin-tools/src/types.ts
@@ -1,4 +1,4 @@
-import type { ToolResult, LocalizedString, ToolConfirmationConfig } from '@stina/extension-api'
+import type { ToolResult, LocalizedString } from '@stina/extension-api'
 import type { ToolExecutionContext } from '@stina/chat'
 
 /**
@@ -29,10 +29,15 @@ export interface BuiltinTool {
   /** Parameter schema (JSON Schema) */
   parameters?: Record<string, unknown>
   /**
-   * Confirmation configuration. If set, user must confirm before tool runs.
-   * If not set, tool runs without confirmation.
+   * Whether this tool requires user confirmation before execution.
+   * Defaults to true if not specified.
    */
-  confirmation?: ToolConfirmationConfig
+  requiresConfirmation?: boolean
+  /**
+   * Optional custom confirmation prompt to show the user.
+   * Only used when confirmation is required.
+   */
+  confirmationPrompt?: LocalizedString
   /**
    * Execute the tool with the given parameters
    * @param params Parameters for the tool

--- a/packages/chat/src/db/ToolConfirmationRepository.ts
+++ b/packages/chat/src/db/ToolConfirmationRepository.ts
@@ -1,0 +1,132 @@
+import { toolConfirmationOverrides } from './schema.js'
+import type { ChatDb } from './schema.js'
+import { eq, and } from 'drizzle-orm'
+
+/**
+ * Tool confirmation override data
+ */
+export interface ToolConfirmationOverride {
+  extensionId: string
+  toolId: string
+  requiresConfirmation: boolean
+  updatedAt: Date
+}
+
+/**
+ * Database repository for tool confirmation overrides.
+ * Manages per-user, per-tool confirmation behavior overrides.
+ * @param db - The chat database instance.
+ * @param userId - User ID for multi-user filtering (required).
+ */
+export class ToolConfirmationRepository {
+  constructor(
+    private db: ChatDb,
+    private userId: string
+  ) {}
+
+  /**
+   * Get all overrides for an extension.
+   * @param extensionId - The extension ID.
+   * @returns Array of tool confirmation overrides.
+   */
+  async getForExtension(extensionId: string): Promise<ToolConfirmationOverride[]> {
+    const rows = await this.db
+      .select()
+      .from(toolConfirmationOverrides)
+      .where(
+        and(
+          eq(toolConfirmationOverrides.userId, this.userId),
+          eq(toolConfirmationOverrides.extensionId, extensionId)
+        )
+      )
+    return rows.map((row) => ({
+      extensionId: row.extensionId,
+      toolId: row.toolId,
+      requiresConfirmation: row.requiresConfirmation,
+      updatedAt: row.updatedAt,
+    }))
+  }
+
+  /**
+   * Get override for a specific tool.
+   * @param extensionId - The extension ID.
+   * @param toolId - The tool ID.
+   * @returns The override value, or null if no override exists.
+   */
+  async get(extensionId: string, toolId: string): Promise<boolean | null> {
+    const rows = await this.db
+      .select()
+      .from(toolConfirmationOverrides)
+      .where(
+        and(
+          eq(toolConfirmationOverrides.userId, this.userId),
+          eq(toolConfirmationOverrides.extensionId, extensionId),
+          eq(toolConfirmationOverrides.toolId, toolId)
+        )
+      )
+    if (rows.length === 0) return null
+    return rows[0]!.requiresConfirmation
+  }
+
+  /**
+   * Set override for a specific tool.
+   * Uses INSERT OR REPLACE for upsert behavior.
+   * @param extensionId - The extension ID.
+   * @param toolId - The tool ID.
+   * @param requiresConfirmation - Whether confirmation is required.
+   */
+  async set(extensionId: string, toolId: string, requiresConfirmation: boolean): Promise<void> {
+    await this.db
+      .insert(toolConfirmationOverrides)
+      .values({
+        userId: this.userId,
+        extensionId,
+        toolId,
+        requiresConfirmation,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [
+          toolConfirmationOverrides.userId,
+          toolConfirmationOverrides.extensionId,
+          toolConfirmationOverrides.toolId,
+        ],
+        set: {
+          requiresConfirmation,
+          updatedAt: new Date(),
+        },
+      })
+  }
+
+  /**
+   * Remove override for a specific tool (revert to manifest default).
+   * @param extensionId - The extension ID.
+   * @param toolId - The tool ID.
+   */
+  async remove(extensionId: string, toolId: string): Promise<void> {
+    await this.db
+      .delete(toolConfirmationOverrides)
+      .where(
+        and(
+          eq(toolConfirmationOverrides.userId, this.userId),
+          eq(toolConfirmationOverrides.extensionId, extensionId),
+          eq(toolConfirmationOverrides.toolId, toolId)
+        )
+      )
+  }
+
+  /**
+   * Reset all overrides for an extension (revert all tools to manifest defaults).
+   * @param extensionId - The extension ID.
+   */
+  async resetForExtension(extensionId: string): Promise<void> {
+    await this.db
+      .delete(toolConfirmationOverrides)
+      .where(
+        and(
+          eq(toolConfirmationOverrides.userId, this.userId),
+          eq(toolConfirmationOverrides.extensionId, extensionId)
+        )
+      )
+  }
+}

--- a/packages/chat/src/db/index.ts
+++ b/packages/chat/src/db/index.ts
@@ -18,6 +18,8 @@ export {
 } from './appSettingsStore.js'
 export { QuickCommandRepository } from './QuickCommandRepository.js'
 export type { QuickCommand, CreateQuickCommandInput, UpdateQuickCommandInput } from './QuickCommandRepository.js'
+export { ToolConfirmationRepository } from './ToolConfirmationRepository.js'
+export type { ToolConfirmationOverride } from './ToolConfirmationRepository.js'
 
 /**
  * Get migrations path for chat package

--- a/packages/chat/src/db/migrations/0010_add_tool_confirmation_overrides.sql
+++ b/packages/chat/src/db/migrations/0010_add_tool_confirmation_overrides.sql
@@ -1,0 +1,14 @@
+-- Tool confirmation overrides
+-- Allows users to override the default confirmation behavior per tool
+CREATE TABLE IF NOT EXISTS tool_confirmation_overrides (
+  user_id         TEXT NOT NULL,
+  extension_id    TEXT NOT NULL,
+  tool_id         TEXT NOT NULL,
+  requires_confirmation INTEGER NOT NULL,  -- 0 = false, 1 = true
+  updated_at      INTEGER NOT NULL,
+  PRIMARY KEY (user_id, extension_id, tool_id)
+);
+CREATE INDEX IF NOT EXISTS idx_tool_conf_user
+  ON tool_confirmation_overrides(user_id);
+CREATE INDEX IF NOT EXISTS idx_tool_conf_user_ext
+  ON tool_confirmation_overrides(user_id, extension_id);

--- a/packages/chat/src/db/schema.ts
+++ b/packages/chat/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 import type { Message, InformationMessage } from '../types/message.js'
 
@@ -132,6 +132,26 @@ export const quickCommands = sqliteTable(
 )
 
 /**
+ * Tool confirmation overrides table
+ * Allows users to override per-tool confirmation behavior
+ */
+export const toolConfirmationOverrides = sqliteTable(
+  'tool_confirmation_overrides',
+  {
+    userId: text('user_id').notNull(),
+    extensionId: text('extension_id').notNull(),
+    toolId: text('tool_id').notNull(),
+    requiresConfirmation: integer('requires_confirmation', { mode: 'boolean' }).notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.userId, table.extensionId, table.toolId] }),
+    userIdx: index('idx_tool_conf_user').on(table.userId),
+    userExtIdx: index('idx_tool_conf_user_ext').on(table.userId, table.extensionId),
+  })
+)
+
+/**
  * Schema export for Drizzle
  */
 export const chatSchema = {
@@ -140,6 +160,7 @@ export const chatSchema = {
   modelConfigs,
   userSettings,
   quickCommands,
+  toolConfirmationOverrides,
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- chat DB is initialized in adapters-node with a different schema object.

--- a/packages/chat/src/orchestrator/ChatOrchestrator.ts
+++ b/packages/chat/src/orchestrator/ChatOrchestrator.ts
@@ -574,6 +574,7 @@ export class ChatOrchestrator {
               confirmationStore: this.deps.confirmationStore,
               localConfirmations: this.pendingConfirmations,
               emitEvent: (event) => this.emitEvent(event),
+              getToolConfirmationOverride: this.deps.getToolConfirmationOverride,
             },
             (id) => toolRegistry.get(id)
           )

--- a/packages/chat/src/orchestrator/types.ts
+++ b/packages/chat/src/orchestrator/types.ts
@@ -118,6 +118,11 @@ export interface ChatOrchestratorDeps {
    */
   confirmationStore?: PendingConfirmationStore
   /**
+   * Look up per-user override for tool confirmation.
+   * Returns true/false if user has set an override, or null for no override (use default).
+   */
+  getToolConfirmationOverride?: (extensionId: string, toolId: string) => Promise<boolean | null>
+  /**
    * Subscriber ID for this orchestrator instance.
    * Used to identify this instance when publishing/subscribing to events.
    */

--- a/packages/chat/src/tools/ToolRegistry.ts
+++ b/packages/chat/src/tools/ToolRegistry.ts
@@ -5,7 +5,7 @@
  * Tools are registered by extensions and made available to AI providers.
  */
 
-import type { ToolResult, LocalizedString, ToolConfirmationConfig } from '@stina/extension-api'
+import type { ToolResult, LocalizedString } from '@stina/extension-api'
 import { resolveLocalizedString } from '@stina/extension-api'
 
 /**
@@ -63,10 +63,10 @@ export interface RegisteredTool {
   extensionId: string
   /** Parameter schema (JSON Schema) */
   parameters?: Record<string, unknown>
-  /**
-   * Confirmation configuration. If set, user must confirm before tool runs.
-   */
-  confirmation?: ToolConfirmationConfig
+  /** Whether this tool requires user confirmation before execution */
+  requiresConfirmation: boolean
+  /** Optional custom confirmation prompt */
+  confirmationPrompt?: LocalizedString
   /**
    * Execute the tool with the given parameters
    * @param params Parameters for the tool

--- a/packages/extension-api/schema/extension-manifest.schema.json
+++ b/packages/extension-api/schema/extension-manifest.schema.json
@@ -857,6 +857,21 @@
                     "type": "object",
                     "additionalProperties": {},
                     "description": "Parameter schema (JSON Schema)"
+                  },
+                  "requiresConfirmation": {
+                    "type": "boolean",
+                    "description": "Whether this tool requires user confirmation before execution (default: true)"
+                  },
+                  "confirmationPrompt": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/ExtensionManifest/properties/contributes/properties/tools/items/properties/name/anyOf/0"
+                      },
+                      {
+                        "$ref": "#/definitions/ExtensionManifest/properties/contributes/properties/tools/items/properties/name/anyOf/1"
+                      }
+                    ],
+                    "description": "Custom confirmation prompt"
                   }
                 },
                 "required": [

--- a/packages/extension-api/src/schemas/contributions.schema.ts
+++ b/packages/extension-api/src/schemas/contributions.schema.ts
@@ -353,6 +353,8 @@ export const ToolDefinitionSchema = z
     name: LocalizedStringSchema.describe('Display name'),
     description: LocalizedStringSchema.describe('Description for Stina'),
     parameters: z.record(z.unknown()).optional().describe('Parameter schema (JSON Schema)'),
+    requiresConfirmation: z.boolean().optional().describe('Whether this tool requires user confirmation before execution (default: true)'),
+    confirmationPrompt: LocalizedStringSchema.optional().describe('Custom confirmation prompt'),
   })
   .describe('Tool definition')
 

--- a/packages/extension-api/src/types.contributions.ts
+++ b/packages/extension-api/src/types.contributions.ts
@@ -374,13 +374,20 @@ export interface ToolDefinition {
   /** Parameter schema (JSON Schema) */
   parameters?: Record<string, unknown>
   /**
-   * Confirmation configuration. If set, user must confirm before tool runs.
-   * If not set, tool runs without confirmation.
+   * Whether this tool requires user confirmation before execution.
+   * Defaults to true if not specified — tools require confirmation unless explicitly opted out.
    */
-  confirmation?: ToolConfirmationConfig
+  requiresConfirmation?: boolean
+  /**
+   * Optional custom confirmation prompt to show the user.
+   * Only used when confirmation is required.
+   * @example { en: "Allow sending email?", sv: "Tillåt att skicka e-post?" }
+   */
+  confirmationPrompt?: LocalizedString
 }
 
 /**
+ * @deprecated Use `requiresConfirmation` and `confirmationPrompt` directly on ToolDefinition instead.
  * Configuration for tool confirmation.
  */
 export interface ToolConfirmationConfig {

--- a/packages/extension-host/src/ExtensionHost.ts
+++ b/packages/extension-host/src/ExtensionHost.ts
@@ -570,11 +570,17 @@ export abstract class ExtensionHost extends EventEmitter<ExtensionHostEvents> {
       return
     }
 
+    // Look up tool definition from manifest for confirmation config
+    const manifestTools = extension.manifest.contributes?.tools
+    const manifestTool = manifestTools?.find((t) => t.id === payload.id)
+
     const tool: ToolInfo = {
       id: payload.id,
       name: payload.name,
       description: payload.description,
       parameters: payload.parameters,
+      requiresConfirmation: manifestTool?.requiresConfirmation !== false, // default true
+      confirmationPrompt: manifestTool?.confirmationPrompt,
       extensionId,
     }
 

--- a/packages/extension-host/src/ExtensionHost.types.ts
+++ b/packages/extension-host/src/ExtensionHost.types.ts
@@ -67,6 +67,10 @@ export interface ToolInfo {
   /** Description - can be a simple string or localized strings */
   description: LocalizedString
   parameters?: Record<string, unknown>
+  /** Whether this tool requires user confirmation before execution */
+  requiresConfirmation: boolean
+  /** Optional custom confirmation prompt */
+  confirmationPrompt?: LocalizedString
   extensionId: string
 }
 

--- a/packages/extension-host/src/ExtensionToolAdapter.ts
+++ b/packages/extension-host/src/ExtensionToolAdapter.ts
@@ -40,6 +40,10 @@ export interface AdaptedTool {
   extensionId: string
   /** Parameter schema (JSON Schema) */
   parameters?: Record<string, unknown>
+  /** Whether this tool requires user confirmation before execution */
+  requiresConfirmation: boolean
+  /** Optional custom confirmation prompt */
+  confirmationPrompt?: LocalizedString
   /**
    * Execute the tool with the given parameters
    * @param params Parameters for the tool
@@ -111,6 +115,8 @@ export class ExtensionToolBridge {
       description: toolInfo.description,
       extensionId: toolInfo.extensionId,
       parameters: toolInfo.parameters,
+      requiresConfirmation: toolInfo.requiresConfirmation,
+      confirmationPrompt: toolInfo.confirmationPrompt,
       execute: async (params: Record<string, unknown>, context?: ToolExecutionContext): Promise<ToolResult> => {
         return this.executeToolInExtension(toolInfo.extensionId, toolInfo.id, params, context?.userId)
       },

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -169,6 +169,9 @@ const en = {
     tab_tools: 'Tools',
     no_tools: 'This extension does not register any tools.',
     parameters: 'Parameters',
+    requires_confirmation: 'Requires confirmation',
+    reset_to_default: 'Reset to default',
+    reset_all_confirmations: 'Reset all to defaults',
     // Manifest validation
     manifest_invalid: 'Invalid manifest – extension will not work',
     // Uninstall confirmation

--- a/packages/i18n/src/locales/sv.ts
+++ b/packages/i18n/src/locales/sv.ts
@@ -167,6 +167,9 @@ const sv = {
     tab_tools: 'Verktyg',
     no_tools: 'Detta tillägg registrerar inga verktyg.',
     parameters: 'Parametrar',
+    requires_confirmation: 'Kräver bekräftelse',
+    reset_to_default: 'Återställ',
+    reset_all_confirmations: 'Återställ alla till standard',
     // Manifest validation
     manifest_invalid: 'Ogiltigt manifest – tillägget fungerar inte',
     // Uninstall confirmation

--- a/packages/ui-vue/src/components/views/settings/Extensions.Details.vue
+++ b/packages/ui-vue/src/components/views/settings/Extensions.Details.vue
@@ -114,6 +114,10 @@ const settingsSaving = ref(false)
 const tools = ref<ExtensionToolInfo[]>([])
 const toolsLoading = ref(false)
 
+// Tool confirmation overrides
+const toolOverrides = ref<Map<string, boolean>>(new Map())
+const overridesLoading = ref(false)
+
 // Active tab for installed extensions
 type Tab = 'info' | 'settings' | 'tools'
 const activeTab = ref<Tab>('info')
@@ -181,6 +185,85 @@ async function loadTools() {
 }
 
 /**
+ * Load tool confirmation overrides for the extension
+ */
+async function loadToolOverrides() {
+  if (!props.installed) return
+
+  overridesLoading.value = true
+  try {
+    const overrides = await api.extensions.getToolConfirmations(props.extension.id)
+    toolOverrides.value = new Map(overrides.map((o) => [o.toolId, o.requiresConfirmation]))
+  } catch (error) {
+    console.error('Failed to load tool confirmation overrides:', error)
+  } finally {
+    overridesLoading.value = false
+  }
+}
+
+/**
+ * Get effective confirmation state for a tool (override or default)
+ */
+function getToolConfirmation(tool: ExtensionToolInfo): boolean {
+  const override = toolOverrides.value.get(tool.id)
+  return override ?? tool.requiresConfirmation
+}
+
+/**
+ * Check if a tool has a user override
+ */
+function hasToolOverride(toolId: string): boolean {
+  return toolOverrides.value.has(toolId)
+}
+
+/**
+ * Toggle tool confirmation override
+ */
+async function toggleToolConfirmation(tool: ExtensionToolInfo) {
+  const currentValue = getToolConfirmation(tool)
+  const newValue = !currentValue
+
+  try {
+    await api.extensions.setToolConfirmation(props.extension.id, tool.id, newValue)
+    toolOverrides.value = new Map(toolOverrides.value)
+    toolOverrides.value.set(tool.id, newValue)
+  } catch (error) {
+    console.error('Failed to update tool confirmation:', error)
+  }
+}
+
+/**
+ * Reset a single tool's override to manifest default
+ */
+async function resetToolOverride(tool: ExtensionToolInfo) {
+  try {
+    await api.extensions.removeToolConfirmation(props.extension.id, tool.id)
+    const newMap = new Map(toolOverrides.value)
+    newMap.delete(tool.id)
+    toolOverrides.value = newMap
+  } catch (error) {
+    console.error('Failed to reset tool override:', error)
+  }
+}
+
+/**
+ * Reset all tool overrides for this extension
+ */
+async function resetAllToolOverrides() {
+  try {
+    await api.extensions.resetToolConfirmations(props.extension.id)
+    toolOverrides.value = new Map()
+  } catch (error) {
+    console.error('Failed to reset tool overrides:', error)
+  }
+}
+
+/**
+ * Whether any overrides exist
+ */
+const hasAnyOverrides = computed(() => toolOverrides.value.size > 0)
+
+/**
  * Resolve a localized string to the current locale
  */
 function resolveString(value: LocalizedString): string {
@@ -230,6 +313,7 @@ watch(
     if (props.installed) {
       loadSettings()
       loadTools()
+      loadToolOverrides()
       activeTab.value = 'info'
     }
   },
@@ -490,24 +574,48 @@ watch(
           <div v-else-if="tools.length === 0" class="empty">
             {{ $t('extensions.no_tools') }}
           </div>
-          <div v-else class="tools-list">
-            <div v-for="tool in tools" :key="tool.id" class="tool-item">
-              <div class="tool-header">
-                <Icon name="wrench-01" class="tool-icon" />
-                <div class="tool-info">
-                  <span class="tool-name">{{ resolveString(tool.name) }}</span>
-                  <code class="tool-id">{{ tool.id }}</code>
+          <template v-else>
+            <div class="tools-list">
+              <div v-for="tool in tools" :key="tool.id" class="tool-item">
+                <div class="tool-header">
+                  <Icon name="wrench-01" class="tool-icon" />
+                  <div class="tool-info">
+                    <span class="tool-name">{{ resolveString(tool.name) }}</span>
+                    <code class="tool-id">{{ tool.id }}</code>
+                  </div>
                 </div>
+                <p class="tool-description">{{ resolveString(tool.description) }}</p>
+                <div class="tool-confirmation">
+                  <label class="confirmation-toggle" @click.prevent="toggleToolConfirmation(tool)">
+                    <input
+                      type="checkbox"
+                      :checked="getToolConfirmation(tool)"
+                      @click.prevent
+                    />
+                    <span class="confirmation-label">{{ $t('extensions.requires_confirmation') }}</span>
+                  </label>
+                  <button
+                    v-if="hasToolOverride(tool.id)"
+                    class="reset-link"
+                    @click="resetToolOverride(tool)"
+                  >
+                    {{ $t('extensions.reset_to_default') }}
+                  </button>
+                </div>
+                <CodeBlock
+                  v-if="tool.parameters"
+                  :content="tool.parameters"
+                  :label="$t('extensions.parameters')"
+                  collapsible
+                />
               </div>
-              <p class="tool-description">{{ resolveString(tool.description) }}</p>
-              <CodeBlock
-                v-if="tool.parameters"
-                :content="tool.parameters"
-                :label="$t('extensions.parameters')"
-                collapsible
-              />
             </div>
-          </div>
+            <div v-if="hasAnyOverrides" class="tools-footer">
+              <button class="reset-all-btn" @click="resetAllToolOverrides">
+                {{ $t('extensions.reset_all_confirmations') }}
+              </button>
+            </div>
+          </template>
         </div>
       </template>
     </div>
@@ -919,6 +1027,63 @@ watch(
         color: var(--theme-general-color-muted);
         line-height: 1.5;
       }
+    }
+  }
+}
+
+.tool-confirmation {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.625rem;
+
+  > .confirmation-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--theme-general-color);
+
+    > input[type="checkbox"] {
+      cursor: pointer;
+      accent-color: var(--theme-general-color-primary);
+    }
+  }
+
+  > .reset-link {
+    background: none;
+    border: none;
+    color: var(--theme-general-color-primary);
+    font-size: 0.75rem;
+    cursor: pointer;
+    padding: 0;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.tools-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--theme-general-border-color);
+  margin-top: 0.5rem;
+
+  > .reset-all-btn {
+    background: none;
+    border: 1px solid var(--theme-general-border-color);
+    color: var(--theme-general-color-muted);
+    font-size: 0.75rem;
+    padding: 0.375rem 0.75rem;
+    border-radius: var(--border-radius-small, 0.375rem);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--theme-general-color);
+      border-color: var(--theme-general-color);
     }
   }
 }

--- a/packages/ui-vue/src/composables/useApi.ts
+++ b/packages/ui-vue/src/composables/useApi.ts
@@ -9,6 +9,7 @@ export type {
   ToolSettingsViewInfo,
   PanelViewInfo,
   ExtensionToolInfo,
+  ToolConfirmationOverride,
   ActionInfo,
   ExtensionEvent,
   ChatEvent,


### PR DESCRIPTION
This pull request introduces a system for managing per-user, per-tool confirmation overrides for extension tools. It adds a new `ToolConfirmationRepository` for storing and retrieving user-specific confirmation preferences, updates the API and client to expose endpoints and methods for managing these overrides, and updates tool type definitions to support the new confirmation model.

The most important changes are:

**Backend: Tool Confirmation Override Infrastructure**
- Added the `ToolConfirmationRepository` to `@stina/chat/db`, providing methods to get, set, remove, and reset per-user tool confirmation overrides in the database. [[1]](diffhunk://#diff-a3d2c738200eb42141114e537b99bfc21d37353db0b39bf735f0b3a637eb4c89R1-R132) [[2]](diffhunk://#diff-97bc270c204e7c696a9eff8061282c4aafd547c81b8e13a6ecdd1f9459e3647eR21-R22)
- Updated backend APIs (`apps/api/src/routes/extensions.ts`) to expose endpoints for getting, setting, removing, and resetting tool confirmation overrides for extension tools.
- Integrated the repository into session management on both API and Electron main process sides, allowing tool confirmation overrides to be respected during tool execution. [[1]](diffhunk://#diff-8155980f74ff23a6d6e09d01a4cf05d0fea6c1ed7944feb603236ca25e976c3fR8) [[2]](diffhunk://#diff-8155980f74ff23a6d6e09d01a4cf05d0fea6c1ed7944feb603236ca25e976c3fR166-R169) [[3]](diffhunk://#diff-4dac2ee23485b513c6ac11eba8dfcc2af1875ccf9fad66c2229eba27ebe762f6L27-R27) [[4]](diffhunk://#diff-4dac2ee23485b513c6ac11eba8dfcc2af1875ccf9fad66c2229eba27ebe762f6R635-R638)

**API Client and Type Updates**
- Extended the API client (`packages/api-client`) to support new methods for managing tool confirmation overrides, and updated type definitions to include `ToolConfirmationOverride`. [[1]](diffhunk://#diff-982099130b40848752981285ab81dad6c2ca68cc24fabb6eda4ca5f2cc97f4b6R36) [[2]](diffhunk://#diff-982099130b40848752981285ab81dad6c2ca68cc24fabb6eda4ca5f2cc97f4b6R977-R1050) [[3]](diffhunk://#diff-a48f88b14a2e1c37e0654f21646338c5cfba65b02ba4e151d036c31d27254ad7R20) [[4]](diffhunk://#diff-ab7e1209a720d8f4c51263df8f7b34a6d7fe20d1a1241c419d8458dd04b6cf83R514-R529) [[5]](diffhunk://#diff-ab7e1209a720d8f4c51263df8f7b34a6d7fe20d1a1241c419d8458dd04b6cf83R187-R200)

**Electron IPC and Preload Integration**
- Added IPC handlers and preload methods in the Electron app to allow the renderer to manage tool confirmation overrides via the new API. [[1]](diffhunk://#diff-4dac2ee23485b513c6ac11eba8dfcc2af1875ccf9fad66c2229eba27ebe762f6R1119-R1146) [[2]](diffhunk://#diff-5d953c075c96e2c7c4c1ad158a81a87d1ca1c9428f4af71909b684134e3580c1R245-R252) [[3]](diffhunk://#diff-41e25aaa89231be2e8d0621a4880c66ac694ba136f7854f7f7bfd3d38a8132a6R163-R168)

**Tool Type and Builtin Tools Update**
- Updated tool type definitions to use `requiresConfirmation` and `confirmationPrompt` instead of the previous `confirmation` config, and updated builtin tool registration accordingly. [[1]](diffhunk://#diff-5a6b0d1f94f44266bbb92372bc0f4f50856796836614214b11488d0e2c090b16L32-R40) [[2]](diffhunk://#diff-cb0a9c3430513fd8229ae481a453669f27c27b83873934c52e9798af7b692ae6L21-R22) [[3]](diffhunk://#diff-5a6b0d1f94f44266bbb92372bc0f4f50856796836614214b11488d0e2c090b16L1-R1)

These changes enable users to customize whether specific extension tools require confirmation before execution, improving flexibility and user control over tool behavior.