### PR TITLE
feat: add orange border on unread interactions with fade-out on focus

### DIFF
--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -142,6 +142,8 @@ const electronAPI = {
     ipcRenderer.invoke('chat-count-interactions', conversationId),
   chatArchiveConversation: (conversationId: string): Promise<void> =>
     ipcRenderer.invoke('chat-archive-conversation', conversationId),
+  chatMarkRead: (conversationId: string): Promise<{ success: boolean }> =>
+    ipcRenderer.invoke('chat-mark-read', conversationId),
   chatCreateConversation: (
     id: string,
     title: string | undefined,

--- a/apps/electron/src/renderer/api/client.ts
+++ b/apps/electron/src/renderer/api/client.ts
@@ -71,6 +71,7 @@ export function createIpcApiClient(): ApiClient {
       sendMessage: (conversationId: string | null, message: string) =>
         api.chatSendMessage(conversationId, message),
       archiveConversation: (id: string) => api.chatArchiveConversation(id),
+      markRead: (conversationId: string) => api.chatMarkRead(conversationId).then(() => {}),
       createConversation: (id: string, title: string | undefined, createdAt: string) =>
         api.chatCreateConversation(id, title, createdAt),
       saveInteraction: (conversationId: string, interaction) =>

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -475,6 +475,20 @@ export function createHttpApiClient(options: ApiClientOptions): ApiClient {
         }
       },
 
+      async markRead(conversationId: string): Promise<void> {
+        const response = await fetch(
+          `${API_BASE}/chat/conversation/${encodeURIComponent(conversationId)}/mark-read`,
+          {
+            method: 'POST',
+            headers: getAuthHeaders(options),
+          }
+        )
+
+        if (!response.ok) {
+          throw new Error(`Failed to mark conversation as read: ${response.statusText}`)
+        }
+      },
+
       async streamMessage(
         conversationId: string | null,
         message: string,

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -434,6 +434,9 @@ export interface ApiClient {
     /** Save an interaction */
     saveInteraction(conversationId: string, interaction: ChatInteractionDTO): Promise<void>
 
+    /** Mark all interactions in a conversation as read */
+    markRead(conversationId: string): Promise<void>
+
     /**
      * Subscribe to a conversation's event stream for real-time multi-client synchronization.
      * Returns an unsubscribe function to clean up the subscription.

--- a/packages/chat/src/mappers/index.ts
+++ b/packages/chat/src/mappers/index.ts
@@ -71,6 +71,7 @@ export function dtoToInteraction(dto: ChatInteractionDTO, conversationId: string
     error: dto.error ?? false,
     errorMessage: dto.errorMessage,
     metadata: { createdAt: dto.createdAt },
+    readAt: dto.readAt,
   }
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -92,6 +92,8 @@ export interface ChatInteractionDTO {
   error: boolean
   /** Error message if the interaction failed */
   errorMessage?: string
+  /** When this interaction was read (undefined = unread) */
+  readAt?: string
 }
 
 /**

--- a/packages/ui-vue/src/components/views/ChatView.Messages.vue
+++ b/packages/ui-vue/src/components/views/ChatView.Messages.vue
@@ -76,6 +76,15 @@ function isErrorMessage(
   return messageIndex === interaction.messages.length - 1
 }
 
+// Helper to get CSS classes for an interaction based on read state
+function getInteractionClasses(interaction: { id: string }): Record<string, boolean> {
+  return {
+    interaction: true,
+    unread: chat.unreadInteractionIds.value.has(interaction.id),
+    reading: chat.readingInteractionIds.value.has(interaction.id),
+  }
+}
+
 // Load more when scrolling to top
 async function handleLoadMore() {
   if (!chat.hasMoreInteractions.value || chat.isLoadingMore.value) return
@@ -135,6 +144,18 @@ watch(
   }
 )
 
+// Watch for reading interactions — clear reading state after fade animation
+watch(
+  () => [...chat.readingInteractionIds.value],
+  (ids) => {
+    if (ids.length > 0) {
+      setTimeout(() => {
+        chat.clearReadingState(ids)
+      }, 2500)
+    }
+  }
+)
+
 // Setup intersection observer and scroll listener
 onMounted(() => {
   // Setup intersection observer for load-more
@@ -188,7 +209,7 @@ onUnmounted(() => {
     <div class="empty"></div>
 
     <!-- Render all loaded interactions -->
-    <div v-for="interaction in chat.interactions.value" :key="interaction.id" class="interaction">
+    <div v-for="interaction in chat.interactions.value" :key="interaction.id" :class="getInteractionClasses(interaction)">
       <!-- Information messages (shown first) -->
       <ChatViewMessagesInfo
         v-for="(info, idx) in interaction.informationMessages"
@@ -283,6 +304,16 @@ onUnmounted(() => {
       color: var(--theme-main-components-chat-interaction-color);
       display: flex;
       flex-direction: column;
+      border-left: 3px solid transparent;
+    }
+
+    &.unread > .inside {
+      border-left-color: var(--theme-main-components-chat-tool-background);
+    }
+
+    &.reading > .inside {
+      border-left-color: transparent;
+      transition: border-left-color 2s ease-out;
     }
   }
 

--- a/packages/ui-vue/src/components/views/ChatView.Messages.vue
+++ b/packages/ui-vue/src/components/views/ChatView.Messages.vue
@@ -151,7 +151,7 @@ watch(
     if (ids.length > 0) {
       setTimeout(() => {
         chat.clearReadingState(ids)
-      }, 2500)
+      }, 2100)
     }
   }
 )
@@ -307,6 +307,7 @@ onUnmounted(() => {
       border-left: 3px solid transparent;
     }
 
+    /* Reuses the tool badge color intentionally for visual consistency */
     &.unread > .inside {
       border-left-color: var(--theme-main-components-chat-tool-background);
     }

--- a/packages/ui-vue/src/components/views/ChatView.service.ts
+++ b/packages/ui-vue/src/components/views/ChatView.service.ts
@@ -893,6 +893,8 @@ export function useChat(options: UseChatOptions = {}) {
     pendingConfirmation.value = null
   }
 
+  // Track focus-gained subscription for cleanup
+  let focusGainedUnsubscribe: (() => void) | null = null
   // Track chat events subscription for cleanup
   let chatEventsUnsubscribe: (() => void) | null = null
   // Track conversation subscription for real-time streaming sync
@@ -1021,7 +1023,7 @@ export function useChat(options: UseChatOptions = {}) {
     await loadDebugMode()
 
     // Mark interactions as read when window gains focus
-    onFocusGained(async () => {
+    focusGainedUnsubscribe = onFocusGained(async () => {
       if (currentConversation.value && unreadInteractionIds.value.size > 0) {
         await markAllAsRead()
       }
@@ -1060,6 +1062,11 @@ export function useChat(options: UseChatOptions = {}) {
     requestControllers.clear()
     if (typeof window !== 'undefined') {
       window.removeEventListener('stina-settings-updated', handleSettingsUpdated)
+    }
+    // Cleanup focus-gained subscription
+    if (focusGainedUnsubscribe) {
+      focusGainedUnsubscribe()
+      focusGainedUnsubscribe = null
     }
     // Cleanup chat events subscription
     if (chatEventsUnsubscribe) {

--- a/packages/ui-vue/src/components/views/ChatView.service.ts
+++ b/packages/ui-vue/src/components/views/ChatView.service.ts
@@ -1,4 +1,4 @@
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import type {
   Conversation,
   Interaction,

--- a/packages/ui-vue/src/composables/useWindowFocus.ts
+++ b/packages/ui-vue/src/composables/useWindowFocus.ts
@@ -1,0 +1,62 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+/**
+ * Tracks window focus state and provides a callback for focus-gained transitions.
+ * Listens to both window focus/blur events and document visibilitychange.
+ */
+export function useWindowFocus() {
+  const isFocused = ref(typeof document !== 'undefined' ? document.visibilityState === 'visible' : true)
+
+  const focusGainedCallbacks: Array<() => void> = []
+
+  function setFocused(focused: boolean): void {
+    const wasFocused = isFocused.value
+    isFocused.value = focused
+    if (!wasFocused && focused) {
+      for (const cb of focusGainedCallbacks) {
+        cb()
+      }
+    }
+  }
+
+  function handleFocus(): void {
+    setFocused(true)
+  }
+
+  function handleBlur(): void {
+    setFocused(false)
+  }
+
+  function handleVisibilityChange(): void {
+    setFocused(document.visibilityState === 'visible')
+  }
+
+  /**
+   * Register a callback that fires when the window transitions from unfocused to focused.
+   * Returns an unsubscribe function.
+   */
+  function onFocusGained(callback: () => void): () => void {
+    focusGainedCallbacks.push(callback)
+    return () => {
+      const idx = focusGainedCallbacks.indexOf(callback)
+      if (idx !== -1) focusGainedCallbacks.splice(idx, 1)
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener('focus', handleFocus)
+    window.addEventListener('blur', handleBlur)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('focus', handleFocus)
+    window.removeEventListener('blur', handleBlur)
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+  })
+
+  return {
+    isFocused,
+    onFocusGained,
+  }
+}

--- a/packages/ui-vue/src/composables/useWindowFocus.ts
+++ b/packages/ui-vue/src/composables/useWindowFocus.ts
@@ -5,7 +5,7 @@ import { ref, onMounted, onUnmounted } from 'vue'
  * Listens to both window focus/blur events and document visibilitychange.
  */
 export function useWindowFocus() {
-  const isFocused = ref(typeof document !== 'undefined' ? document.visibilityState === 'visible' : true)
+  const isFocused = ref(typeof document !== 'undefined' ? document.hasFocus() && document.visibilityState === 'visible' : true)
 
   const focusGainedCallbacks: Array<() => void> = []
 


### PR DESCRIPTION
Interactions received while the app is unfocused are visually marked with an orange left border that fades out over 2 seconds when the window regains focus. Wires up the existing backend mark-read API through all client layers (HTTP, Electron IPC) and adds a new useWindowFocus composable for focus state tracking.